### PR TITLE
Disable the bad-continuation Pylint rule

### DIFF
--- a/{{cookiecutter.project_name}}/.pylintrc
+++ b/{{cookiecutter.project_name}}/.pylintrc
@@ -133,7 +133,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,
+        bad-continuation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
This rule emits a false positive under certain situations. See https://github.com/PyCQA/pylint/issues/289