### PR TITLE
fix: Change to Azure provided build bage

### DIFF
--- a/{{cookiecutter.project_name}}/README.md
+++ b/{{cookiecutter.project_name}}/README.md
@@ -1,9 +1,7 @@
 # {{ cookiecutter.project_name }}
 
 {% if cookiecutter.ci|lower == "azure" -%}
-[![Azure DevOps builds](https://img.shields.io/azure-devops/build/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/{{cookiecutter.azure_build_definition_id }}/master.svg)](https://dev.azure.com/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/_build/latest?definitionId={{cookiecutter.azure_build_definition_id }}&branchName=master)
-[![Azure DevOps tests](https://img.shields.io/azure-devops/tests/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/{{cookiecutter.azure_build_definition_id }}/master.svg)](https://dev.azure.com/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/_build/latest?definitionId={{cookiecutter.azure_build_definition_id }}&branchName=master)
-[![Azure DevOps coverage](https://img.shields.io/azure-devops/coverage/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/{{cookiecutter.azure_build_definition_id }}/master.svg)](https://dev.azure.com/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/_build/latest?definitionId={{cookiecutter.azure_build_definition_id }}&branchName=master)
+[![Build Status](https://dev.azure.com/tomtomweb/{{ cookiecutter.ci_org_name }}/_apis/build/status/{{ cookiecutter.ci_project_name }}/?branchName=master)](https://dev.azure.com/{{ cookiecutter.ci_org_name }}/{{ cookiecutter.ci_project_name }}/_build/latest?definitionId={{cookiecutter.azure_build_definition_id }}&branchName=master)
 {% endif %}
 {% if cookiecutter.vs|lower == "github" -%}
 [![PyPI - Version](https://img.shields.io/pypi/v/{{ cookiecutter.project_name }}.svg)](https://pypi.org/project/{{ cookiecutter.project_name }}/)


### PR DESCRIPTION
Since the shields.io instructions for Azure pipelines seem to be out of date, and also stop working after there haven't been any builds for the past two weeks because the builds get deleted in Azure, here is an approach which uses the Azure status badge - which seems to retain the current status of the build.