### PR TITLE
feat: Add optional configuration of Black formatter

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,10 @@
 {
     "full_name": "John Doe",
     "email": "john.doe@example.com",
-
-    "vs": ["github", "bitbucket"],
+    "vs": [
+        "github",
+        "bitbucket"
+    ],
     "vs_url": "{% if cookiecutter.vs|lower == 'github' %}github.com{% else %}bitbucket.your_org.com{% endif %}",
     "vs_account": "{% if cookiecutter.vs|lower == 'github' %}tomtom-international{% else %}NAV{% endif %}",
 
@@ -10,6 +12,8 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
     "project_short_description": "Describe in a short sentence your Python package.",
     "version": "0.0.1-dev",
+
+    "use_black_formatter": "n",
 
     "ci": "{% if cookiecutter.vs|lower == 'github' %}azure{% else %}jenkins{% endif %}",
     "ci_url": "{% if cookiecutter.ci|lower == 'azure' %}https://dev.azure.com{% else %}https://jenkins.your_org.com{% endif %}",

--- a/{{cookiecutter.project_name}}/.pylintrc
+++ b/{{cookiecutter.project_name}}/.pylintrc
@@ -133,7 +133,8 @@ disable=print-statement,
         xreadlines-attribute,
         deprecated-sys-function,
         exception-escape,
-        comprehension-escape
+        comprehension-escape,{% if cookiecutter.use_black_formatter|lower == "y" %}
+        bad-continuation, # Disable for use with black{% endif %}
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -1,0 +1,17 @@
+{% if cookiecutter.use_black_formatter|lower == "y" -%}
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+{% endif %}

--- a/{{cookiecutter.project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_name}}/requirements_dev.txt
@@ -20,3 +20,7 @@ pytest-pylint==0.14.0
 pytest-runner==5.1
 setuptools-lint==0.6.0
 tox==3.12.1
+
+{% if cookiecutter.use_black_formatter|lower == "y" -%}
+pytest-black==0.3.7
+{% endif %}

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -23,8 +23,8 @@ universal = 1
 test = pytest
 
 [tool:pytest]
-addopts = -s -vv --cov-report xml:build/coverage.xml --cov-report term --cov-branch --cov {{ cookiecutter.project_slug }} --junitxml=build/test_results.xml
-testpaths = tests
+addopts = -s -vv --cov-report xml:build/coverage.xml --cov-report term --cov-branch --cov {{ cookiecutter.project_slug }} --junitxml=build/test_results.xml{% if cookiecutter.use_black_formatter|lower == "y" %} --black{% endif %}
+testpaths = tests{% if cookiecutter.use_black_formatter|lower == "y" %} {{ cookiecutter.project_slug }} {% endif %}
 collect_ignore = ['setup.py']
 
 [coverage:report]


### PR DESCRIPTION
Allows you to answer `y` to `use_black_formatter`, in which case the black and pytest-black will be configured. As a result, in both CI and locally, when running tests black formatting will be verified (*not* applied). By default this will not be configured.