### PR TITLE
feat: Send sdist output to temp directory to avoid issues on dev systems

### DIFF
--- a/{{cookiecutter.project_name}}/Dockerfile
+++ b/{{cookiecutter.project_name}}/Dockerfile
@@ -16,8 +16,8 @@ RUN pip install --upgrade virtualenv==16.6.0 && python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 COPY . /code
 WORKDIR /code
-RUN python setup.py sdist \
-  && pip install dist/*
+RUN DIST_DIR=$(mktemp -d) && python setup.py sdist --dist-dir $DIST_DIR\
+  && pip install $DIST_DIR/*.tar.gz
 
 
 FROM $PYTHON_BASE


### PR DESCRIPTION
Prevents issues where `python setup.py install` has deposited a `*.egg` file into the `dist` directory. Also avoids issues if multiple versions of the same packages are in the `dist` directory.