### PR TITLE
feat: Add option for using spellcheck

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,7 @@
     "version": "0.0.1-dev",
 
     "use_black_formatter": "n",
+    "use_spellcheck": "n",
 
     "ci": "{% if cookiecutter.vs|lower == 'github' %}azure{% else %}jenkins{% endif %}",
     "ci_url": "{% if cookiecutter.ci|lower == 'azure' %}https://dev.azure.com{% else %}https://jenkins.your_org.com{% endif %}",

--- a/{{cookiecutter.project_name}}/.pylintrc
+++ b/{{cookiecutter.project_name}}/.pylintrc
@@ -195,10 +195,10 @@ max-spelling-suggestions=4
 
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict=
+spelling-dict={% if cookiecutter.use_spellcheck|lower == "y" -%}en_US{% endif %}
 
 # List of comma separated words that should not be checked.
-spelling-ignore-words=
+spelling-ignore-words={% if cookiecutter.use_spellcheck|lower == "y" -%}args, bool, yaml, str, config, py, dicts, api{% endif %}
 
 # A path to a file that contains private dictionary; one word per line.
 spelling-private-dict-file=

--- a/{{cookiecutter.project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_name}}/requirements_dev.txt
@@ -24,3 +24,6 @@ tox==3.12.1
 {% if cookiecutter.use_black_formatter|lower == "y" -%}
 pytest-black==0.3.7
 {% endif %}
+{% if cookiecutter.use_spellcheck|lower == "y" -%}
+pyenchant==2.0.0
+{% endif %}


### PR DESCRIPTION
Adds a default-disabled option to using the spelling feature in Pylint.
For Azure pipeline, depends on this PR: https://github.com/tomtom-international/azure-pipeline-templates/pull/16 as Windows and MacOS agents do not have Enchant installed.

If this were to get used much, we could look at providing a private dictionary file with common terms in Python, I've already included a few.