### PR TITLE
Add bandit option and configuration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,6 +14,7 @@
     "version": "0.0.1-dev",
 
     "use_black_formatter": "n",
+    "use_bandit_sec_scan": "n",
 
     "ci": "{% if cookiecutter.vs|lower == 'github' %}azure{% else %}jenkins{% endif %}",
     "ci_url": "{% if cookiecutter.ci|lower == 'azure' %}https://dev.azure.com{% else %}https://jenkins.your_org.com{% endif %}",

--- a/{{cookiecutter.project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_name}}/requirements_dev.txt
@@ -24,3 +24,6 @@ tox==3.12.1
 {% if cookiecutter.use_black_formatter|lower == "y" -%}
 pytest-black==0.3.7
 {% endif %}
+{% if cookiecutter.use_bandit_sec_scan|lower == "y" -%}
+pytest-bandit==0.5.1
+{% endif %}

--- a/{{cookiecutter.project_name}}/setup.cfg
+++ b/{{cookiecutter.project_name}}/setup.cfg
@@ -26,6 +26,10 @@ test = pytest
 addopts = -s -vv --cov-report xml:build/coverage.xml --cov-report term --cov-branch --cov {{ cookiecutter.project_slug }} --junitxml=build/test_results.xml{% if cookiecutter.use_black_formatter|lower == "y" %} --black{% endif %}
 testpaths = tests{% if cookiecutter.use_black_formatter|lower == "y" %} {{ cookiecutter.project_slug }} {% endif %}
 collect_ignore = ['setup.py']
+{% if cookiecutter.use_bandit_sec_scan|lower == "y" -%}
+bandit_targets = {{ cookiecutter.project_slug }}
+bandit_recurse = true
+{% endif %}
 
 [coverage:report]
 show_missing = true


### PR DESCRIPTION
Provides the option to configure [bandit](https://pypi.org/project/bandit/) for static security scanning.
Disabled by default.