### PR TITLE
feat: use pip 19.2.1

### DIFF
--- a/{{cookiecutter.project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_name}}/requirements_dev.txt
@@ -2,7 +2,7 @@
 # Example:
 # --extra-index-url https://artifactory.acme.org/artifactory/api/pypi/pypi-local/simple
 
-pip==19.1.1
+pip==19.2.1
 setuptools==41.0.1
 virtualenv==16.6.0
 


### PR DESCRIPTION
Module pip 19.2.1 version is available. To avoid warnings and stay up to date pin latest version.