### PR TITLE
feat(pylint): generate pylintrc out of pylint directly

### DIFF
--- a/{{cookiecutter.project_name}}/.pylintrc
+++ b/{{cookiecutter.project_name}}/.pylintrc
@@ -2,7 +2,7 @@
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
-# run arbitrary code
+# run arbitrary code.
 extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
@@ -17,8 +17,14 @@ ignore-patterns=
 # pygtk.require().
 #init-hook=
 
-# Use multiple processes to speed up Pylint.
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
 jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
@@ -31,7 +37,7 @@ persistent=yes
 #rcfile=
 
 # When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
+# user-friendly hints instead of false-positive error messages.
 suggestion-mode=yes
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
@@ -42,18 +48,18 @@ unsafe-load-any-extension=no
 [MESSAGES CONTROL]
 
 # Only show warnings with the listed confidence levels. Leave empty to show
-# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
 confidence=
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
-# file where it should appear only once).You can also use "--disable=all" to
+# file where it should appear only once). You can also use "--disable=all" to
 # disable everything first and then reenable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
-# no Warning level messages displayed, use"--disable=all --enable=classes
-# --disable=W"
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
 disable=print-statement,
         parameter-unpacking,
         unpacking-in-except,
@@ -64,15 +70,14 @@ disable=print-statement,
         old-octal-literal,
         import-star-module-level,
         non-ascii-bytes-literal,
-        invalid-unicode-literal,
         raw-checker-failed,
         bad-inline-option,
         locally-disabled,
-        locally-enabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
+        use-symbolic-message-instead,
         apply-builtin,
         basestring-builtin,
         buffer-builtin,
@@ -153,15 +158,15 @@ enable=c-extension-no-member
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
 
 # Template used to display messages. This is a python new-style format string
-# used to format the message information. See doc for all details
+# used to format the message information. See doc for all details.
 #msg-template=
 
 # Set the output format. Available formats are text, parseable, colorized, json
-# and msvs (visual studio).You can also give a reporter class, eg
+# and msvs (visual studio). You can also give a reporter class, e.g.
 # mypackage.mymodule.MyReporterClass.
 output-format=text
 
-# Tells whether to display a full report or only the messages
+# Tells whether to display a full report or only the messages.
 reports=no
 
 # Activate the evaluation score.
@@ -177,20 +182,23 @@ max-nested-blocks=5
 # inconsistent-return-statements if a never returning function is called then
 # it will be considered as an explicit return statement and no message will be
 # printed.
-never-returning-functions=optparse.Values,sys.exit
+never-returning-functions=sys.exit
 
 
-[MISCELLANEOUS]
+[LOGGING]
 
-# List of note tags to take in consideration, separated by a comma.
-notes=FIXME,
-      XXX,
-      TODO
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
 
 
 [SPELLING]
 
-# Limits count of emitted suggestions for spelling mistakes
+# Limits count of emitted suggestions for spelling mistakes.
 max-spelling-suggestions=4
 
 # Spelling dictionary name. Available dictionaries: none. To make it working
@@ -211,41 +219,12 @@ spelling-private-dict-file=
 spelling-store-unknown-words=no
 
 
-[FORMAT]
+[MISCELLANEOUS]
 
-# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
-expected-line-ending-format=
-
-# Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
-
-# Number of spaces of indent required inside a hanging  or continued line.
-indent-after-paren=4
-
-# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
-# tab).
-indent-string='    '
-
-# Maximum number of characters on a single line.
-max-line-length=180
-
-# Maximum number of lines in a module
-max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
-# Allow the body of a class to be on the same line as the declaration if body
-# contains single statement.
-single-line-class-stmt=no
-
-# Allow the body of an if to be on the same line as the test if there is no
-# else.
-single-line-if-stmt=no
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
 
 
 [TYPECHECK]
@@ -263,6 +242,10 @@ generated-members=requests.codes.ok
 # Tells whether missing members accessed in mixin class should be ignored. A
 # mixin class is detected if its name ends with "mixin" (case insensitive).
 ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
 
 # This flag controls whether pylint should warn about no-member and similar
 # checks whenever an opaque object is returned when inferring. The inference
@@ -296,6 +279,73 @@ missing-member-hint-distance=1
 missing-member-max-choices=1
 
 
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
 [SIMILARITIES]
 
 # Ignore comments when computing similarities.
@@ -311,30 +361,23 @@ ignore-imports=no
 min-similarity-lines=4
 
 
-[LOGGING]
-
-# Logging modules to check that the string format arguments are in logging
-# function parameter format
-logging-modules=logging
-
-
 [BASIC]
 
-# Naming style matching correct argument names
+# Naming style matching correct argument names.
 argument-naming-style=snake_case
 
 # Regular expression matching correct argument names. Overrides argument-
-# naming-style
+# naming-style.
 #argument-rgx=
 
-# Naming style matching correct attribute names
+# Naming style matching correct attribute names.
 attr-naming-style=snake_case
 
 # Regular expression matching correct attribute names. Overrides attr-naming-
-# style
+# style.
 #attr-rgx=
 
-# Bad variable names which should always be refused, separated by a comma
+# Bad variable names which should always be refused, separated by a comma.
 bad-names=foo,
           bar,
           baz,
@@ -342,38 +385,39 @@ bad-names=foo,
           tutu,
           tata
 
-# Naming style matching correct class attribute names
+# Naming style matching correct class attribute names.
 class-attribute-naming-style=any
 
 # Regular expression matching correct class attribute names. Overrides class-
-# attribute-naming-style
+# attribute-naming-style.
 #class-attribute-rgx=
 
-# Naming style matching correct class names
+# Naming style matching correct class names.
 class-naming-style=PascalCase
 
-# Regular expression matching correct class names. Overrides class-naming-style
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
 #class-rgx=
 
-# Naming style matching correct constant names
+# Naming style matching correct constant names.
 const-naming-style=UPPER_CASE
 
 # Regular expression matching correct constant names. Overrides const-naming-
-# style
+# style.
 #const-rgx=
 
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=-1
 
-# Naming style matching correct function names
+# Naming style matching correct function names.
 function-naming-style=snake_case
 
 # Regular expression matching correct function names. Overrides function-
-# naming-style
+# naming-style.
 #function-rgx=
 
-# Good variable names which should always be accepted, separated by a comma
+# Good variable names which should always be accepted, separated by a comma.
 good-names=i,
            j,
            k,
@@ -381,28 +425,28 @@ good-names=i,
            Run,
            _
 
-# Include a hint for the correct naming format with invalid-name
+# Include a hint for the correct naming format with invalid-name.
 include-naming-hint=no
 
-# Naming style matching correct inline iteration names
+# Naming style matching correct inline iteration names.
 inlinevar-naming-style=any
 
 # Regular expression matching correct inline iteration names. Overrides
-# inlinevar-naming-style
+# inlinevar-naming-style.
 #inlinevar-rgx=
 
-# Naming style matching correct method names
+# Naming style matching correct method names.
 method-naming-style=snake_case
 
 # Regular expression matching correct method names. Overrides method-naming-
-# style
+# style.
 #method-rgx=
 
-# Naming style matching correct module names
+# Naming style matching correct module names.
 module-naming-style=snake_case
 
 # Regular expression matching correct module names. Overrides module-naming-
-# style
+# style.
 #module-rgx=
 
 # Colon-delimited sets of names that determine each other's naming style when
@@ -415,44 +459,56 @@ no-docstring-rgx=^_
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
 property-classes=abc.abstractproperty
 
-# Naming style matching correct variable names
+# Naming style matching correct variable names.
 variable-naming-style=snake_case
 
 # Regular expression matching correct variable names. Overrides variable-
-# naming-style
+# naming-style.
 #variable-rgx=
 
 
-[VARIABLES]
+[STRING]
 
-# List of additional names supposed to be defined in builtins. Remember that
-# you should avoid to define new builtins when possible.
-additional-builtins=
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
 
-# Tells whether unused global variables should be treated as a violation.
-allow-global-unused-variables=yes
 
-# List of strings which can identify a callback function by name. A callback
-# name must start or end with one of those strings.
-callbacks=cb_,
-          _cb
+[IMPORTS]
 
-# A regular expression matching the name of dummy variables (i.e. expectedly
-# not used).
-dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
 
-# Argument names that match this expression will be ignored. Default to name
-# with leading underscore
-ignored-argument-names=_.*|^ignored_|^unused_
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
 
-# Tells whether we should check for unused import in __init__ files.
-init-import=no
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
 
-# List of qualified module names which can have objects that can redefine
-# builtins.
-redefining-builtins-modules=six.moves,past.builtins,future.builtins,io
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
 
 
 [CLASSES]
@@ -474,24 +530,24 @@ exclude-protected=_asdict,
 valid-classmethod-first-arg=cls
 
 # List of valid names for the first argument in a metaclass class method.
-valid-metaclass-classmethod-first-arg=mcs
+valid-metaclass-classmethod-first-arg=cls
 
 
 [DESIGN]
 
-# Maximum number of arguments for function / method
+# Maximum number of arguments for function / method.
 max-args=5
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=7
 
-# Maximum number of boolean expressions in a if statement
+# Maximum number of boolean expressions in an if statement.
 max-bool-expr=5
 
-# Maximum number of branch for function / method body
+# Maximum number of branch for function / method body.
 max-branches=12
 
-# Maximum number of locals for function / method body
+# Maximum number of locals for function / method body.
 max-locals=15
 
 # Maximum number of parents for a class (see R0901).
@@ -500,51 +556,19 @@ max-parents=7
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20
 
-# Maximum number of return / yield for function / method body
+# Maximum number of return / yield for function / method body.
 max-returns=6
 
-# Maximum number of statements in function / method body
+# Maximum number of statements in function / method body.
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=2
 
 
-[IMPORTS]
-
-# Allow wildcard imports from modules that define __all__.
-allow-wildcard-with-all=no
-
-# Analyse import fallback blocks. This can be used to support both Python 2 and
-# 3 compatible code, which means that the block might have code that exists
-# only in one or another interpreter, leading to false positives when analysed.
-analyse-fallback-blocks=no
-
-# Deprecated modules which should not be used, separated by a comma
-deprecated-modules=optparse,tkinter.tix
-
-# Create a graph of external dependencies in the given file (report RP0402 must
-# not be disabled)
-ext-import-graph=
-
-# Create a graph of every (i.e. internal and external) dependencies in the
-# given file (report RP0402 must not be disabled)
-import-graph=
-
-# Create a graph of internal dependencies in the given file (report RP0402 must
-# not be disabled)
-int-import-graph=
-
-# Force import order to recognize a module as part of the standard
-# compatibility libraries.
-known-standard-library=
-
-# Force import order to recognize a module as part of a third party library.
-known-third-party=enchant
-
-
 [EXCEPTIONS]
 
 # Exceptions that will emit a warning when being caught. Defaults to
-# "Exception"
-overgeneral-exceptions=Exception
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception


### PR DESCRIPTION
I ran `pylint --generate-rcfile > \{\{cookiecutter.project_name\}\}/.pylintrc` to generate the file based on pylint version 2.3.1 to ensure we don't drift that much away from the default configuration