### PR TITLE
fix: correct pyproject.toml

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -15,3 +15,5 @@ exclude = '''
   | build
   | dist
 {% endif %}
+/)
+'''


### PR DESCRIPTION
Adds the missing parens and quotes to pyproject.toml so it is valid.