### PR TITLE
fix: Adding dist folder to .dockeignore file

### DIFF
--- a/{{cookiecutter.project_name}}/.dockerignore
+++ b/{{cookiecutter.project_name}}/.dockerignore
@@ -2,6 +2,7 @@
 .gitignore
 .pylintrc
 .md
+dist/
 {% if cookiecutter.ci|lower == "azure" -%}
 azure-pipelines.yml
 {% elif cookiecutter.ci|lower == "jenkins" -%}


### PR DESCRIPTION
This change is required in case some leftovers from a local build are lingering around. The COPY . command in the Dockerfile will copy the folder as well to the build context and it might happen that during pip install dist/* it will use an older artifact.

