### PR TITLE
feat: Install extra requirements as part of setup requirements

### DIFF
--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -22,10 +22,10 @@ with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
 requirements = []
-extra_requirements = {}
+extras_require = {}
 # Ensure that linting and testing will be done with all depedencies installed
 collected_extras = []
-for req_set in extra_requirements.values():
+for req_set in extras_require.values():
     collected_extras += req_set
 
 # pytest-runner is needed to be able to call `python setup.py test` and use pytest to
@@ -104,6 +104,9 @@ setup(
 
     # List of dependencies required before running the setup script.
     setup_requires=setup_requirements,
+
+    # Dictionary of dependencies that are optional but enable certain features
+    extras_require=extras_require,
 
     # List of dependencies required during test execution.
     tests_require=test_requirements,

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -25,7 +25,7 @@ requirements = []
 extra_requirements = {}
 # Ensure that linting and testing will be done with all depedencies installed
 collected_extras = []
-for req_set_name, req_set in extra_requirements.items():
+for req_set in extra_requirements.values():
     collected_extras += req_set
 
 # pytest-runner is needed to be able to call `python setup.py test` and use pytest to

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -21,11 +21,16 @@ with open("README.md") as readme_file:
 with open("CHANGELOG.md") as changelog_file:
     changelog = changelog_file.read()
 
-
 requirements = []
+extra_requirements = {}
+# Ensure that linting and testing will be done with all depedencies installed
+collected_extras = []
+for req_set_name, req_set in extra_requirements.items():
+    collected_extras += req_set
+
 # pytest-runner is needed to be able to call `python setup.py test` and use pytest to
 # execute the tests
-setup_requirements = ["pytest-runner",]
+setup_requirements = ["pytest-runner",] + collected_extras
 test_requirements = ["pytest", "pytest-cov", "coverage",]
 
 


### PR DESCRIPTION
In order to perform linting and tests, you must have optional dependencies installed.
The extra requirements are added to the setup_requirements due to the fact that linting doesn't have it's own requires step.