### PR TITLE
fix: add generic info instead of exact command to install package from the sources instead of using the exact command

### DIFF
--- a/{{cookiecutter.project_name}}/docs/installation.rst
+++ b/{{cookiecutter.project_name}}/docs/installation.rst
@@ -26,22 +26,7 @@ you through the process.
 From sources
 ------------
 
-The sources for {{ cookiecutter.project_name }} can be downloaded from the `{{ cookiecutter.vs|title }} repo`_.
-
-You can either clone the public repository:
-
-.. code-block:: console
-
-    $ git clone ssh://git@{{ cookiecutter.vs_url }}{% if cookiecutter.vs|lower == "bitbucket" %}:7999{% endif %}/{{ cookiecutter.vs_account }}/{{ cookiecutter.project_name }}.git
-
-{% if cookiecutter.vs|lower == "github" -%}
-Or download the `tarball`_:
-
-.. code-block:: console
-
-    $ curl  -OL https://{{ cookiecutter.vs_url }}/{{ cookiecutter.vs_account }}/{{ cookiecutter.project_name }}/tarball/master
-
-{% endif -%}
+Checkout the `{{ cookiecutter.project_name }}`_ from {{ cookiecutter.vs|title }}.
 
 Once you have a copy of the source, you can install it with:
 
@@ -51,8 +36,8 @@ Once you have a copy of the source, you can install it with:
 
 
 {% if cookiecutter.vs|lower == "github" -%}
-.. _{{ cookiecutter.vs|title }} repo: https://{{ cookiecutter.vs_url }}/{{ cookiecutter.vs_account }}/{{ cookiecutter.project_name }}
+.. _{{ cookiecutter.project_name }}: https://{{ cookiecutter.vs_url }}/{{ cookiecutter.vs_account }}/{{ cookiecutter.project_name }}
 .. _tarball: https://{{ cookiecutter.vs_url }}/{{ cookiecutter.vs_account }}/{{ cookiecutter.project_name }}/tarball/master
 {% elif cookiecutter.vs|lower == "bitbucket" -%}
-.. _{{ cookiecutter.vs|title }} repo: https://{{ cookiecutter.vs_url }}/projects/{{ cookiecutter.vs_account }}/repos/{{ cookiecutter.project_name }}
+.. _{{ cookiecutter.project_name }}: https://{{ cookiecutter.vs_url }}/projects/{{ cookiecutter.vs_account }}/repos/{{ cookiecutter.project_name }}
 {% endif -%}


### PR DESCRIPTION
Add generic info in the installation.rst to install package from the sources instead of using the exact command.