### PR TITLE
feat: Add ghp-import plugin to deploy docs

### DIFF
--- a/{{cookiecutter.project_name}}/requirements_dev.txt
+++ b/{{cookiecutter.project_name}}/requirements_dev.txt
@@ -9,6 +9,7 @@ bumpversion==0.5.3
 twine==1.13.0
 
 cmarkgfm==0.4.2
+ghp-import==0.5.5
 m2r==0.2.1
 recommonmark==0.5.0
 Sphinx==2.1.0


### PR DESCRIPTION
Add `ghp-import` plugin in the requirements to deploy Sphinx built HTML files to Bitbucket/Github repo